### PR TITLE
Fix issues in Microsoft Edge

### DIFF
--- a/src/app/lib/fetch.js
+++ b/src/app/lib/fetch.js
@@ -1,3 +1,6 @@
+import { fromPairs } from 'lodash-es';
+
+
 /**
  * Takes a `fetch()` response and either returns resolved `Response`
  *   if 200 <= response.status < 300. Otherwise or a rejected
@@ -21,15 +24,20 @@ export function checkStatus(response) {
  * Parses the `fetch` `response.headers` object. As there are
  *   there are subtle differences between `whatwg-fetch` and
  *   `node-fetch`, we need a way to do this in a way that
- *   handles both the server and browser.
- * @param {Response} response Response from `fetch()`
- * @returns {Response|Promise} Raw Response or rejected `Promise`
+ *   handles both the server and browser. Microsoft Edge is also
+ *   missing key interfaces on `Headers`.
+ * @param {Headers|Object} headers Headers object from `fetch()`
+ * @returns {Object} Object containing key value pairs
  */
 export function parseHeaders(headers) {
   if (__SERVER__) {
     return Object.keys(headers.raw())
       .reduce((acc, key) => ({ ...acc, [key]: headers.get(key) }), {});
   }
-  return Array.from(headers.entries())
-    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+  if (headers instanceof Headers && Headers.prototype.entries) {
+    return fromPairs(Array.from(headers.entries()));
+  }
+  const pairs = [];
+  headers.forEach((value, key) => pairs.push([key, value]));
+  return fromPairs(pairs);
 }


### PR DESCRIPTION
`Headers.prototype.entries` does not exist in Microsoft Edge. This PR uses an alternative for when this is the case.
